### PR TITLE
Removing the assumption that the cssLint config is in the cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ var cssLintPlugin = function(options) {
   // Read CSSLint options from a specified csslintrc file.
   if (typeof options === 'string') {
     // Don't catch readFile errors, let them bubble up
-    var externalOptions = fs.readFileSync('./'+options);
+    var externalOptions = fs.readFileSync(options);
 
     try {
       options = JSON.parse(externalOptions);


### PR DESCRIPTION
This would fix #13.