### PR TITLE
Bump dependencies, and test on latest Node as well as Io.js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
+  - iojs
+  - 0.12
   - 0.10

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "main": "index.js",
   "dependencies": {
     "csslint": "^0.10.0",
-    "event-stream": "^3.1.2",
-    "gulp-util": "^3.0.0"
+    "event-stream": "^3.3.0",
+    "gulp-util": "^3.0.4"
   },
   "devDependencies": {
-    "mocha": "^1.18.2",
-    "should": "^3.3.1"
+    "mocha": "^2.2.1",
+    "should": "^5.2.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Dependencies already installed the same versions anyway, so no difference there.
Tests pass, so no problem bumping devDeps