### PR TITLE
Built in formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,20 @@ file.csslint.results = []; // CSSLint errors
 file.csslint.opt = {}; // The options you passed to CSSLint
 ```
 
-## Custom Reporters
+## Using reporters
+
+Several reporters come built-in to css-lint. To use one of these reporters, pass the name to `csslint.reporter`.
+
+For a list of all reporters supported by `csslint`, see the [csslint wiki](https://github.com/CSSLint/csslint/wiki/Command-line-interface#--format).
+
+```js
+gulp.task('lint', function() {
+  gulp.files('lib/*.css')
+    .pipe(csslint())
+    .pipe(csslint.reporter('junit-xml'));
+```
+
+### Custom Reporters
 
 Custom reporter functions can be passed as `csslint.reporter(reporterFunc)`. The reporter function will be called for each linted file and passed the file object as described above.
 
@@ -118,7 +131,7 @@ gulp.task('lint', function() {
   gulp.files('lib/*.css')
     .pipe(csslint())
     .pipe(csslint.reporter()) // Display errors
-    .pipe(csslint.failReporter()); // Fail on error
+    .pipe(csslint.reporter('fail')); // Fail on error (or csslint.failReporter())
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   ],
   "dependencies": {
     "csslint": "^0.10.0",
-    "event-stream": "^3.3.1",
     "gulp-util": "^3.0.4",
-    "rcloader": "^0.1.4"
+    "rcloader": "^0.1.4",
+    "through2": "^2.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
@@ -19,7 +19,8 @@
     "jshint": "^2.7.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.3.4",
-    "should": "^6.0.3"
+    "should": "^7.0.3",
+    "sinon": "^1.15.4"
   },
   "scripts": {
     "clean": "rimraf coverage/",


### PR DESCRIPTION
#1 (not tagging in commit (yet), as I foresee a lot of rebasing, and it gets noisy in that issue).

This is a rough start on using the build in formatters.

I haven't tested with multiple css-files, or multiple violations, but a single file with a single violation works fine.

The tests seems convoluted as well, any ideas on how to clean it up?