### PR TITLE
Custom formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ var csslint = require('gulp-csslint');
 gulp.task('css', function() {
   gulp.src('client/css/*.css')
     .pipe(csslint())
-    .pipe(csslint.reporter());
+    .pipe(csslint.formatter());
 });
 ```
 
@@ -39,7 +39,7 @@ gulp.src('client/css/*.css')
   .pipe(csslint({
     'shorthand': false
   }))
-  .pipe(csslint.reporter());
+  .pipe(csslint.formatter());
 ```
 
 ### csslint(csslintrc)
@@ -52,7 +52,7 @@ You can also pass the path to your csslintrc file instead of a rule configuratio
 ```js
 gulp.src('client/css/*.css')
   .pipe(csslint('csslintrc.json'))
-  .pipe(csslint.reporter());
+  .pipe(csslint.formatter());
 ```
 
 ## Results
@@ -66,28 +66,28 @@ file.csslint.results = []; // CSSLint errors
 file.csslint.opt = {}; // The options you passed to CSSLint
 ```
 
-## Using reporters
+## Using formatters
 
-Several reporters come built-in to css-lint. To use one of these reporters, pass the name to `csslint.reporter`.
+Several formatters come built-in to CSSLint. To use one of these formatters, pass the name to `csslint.formatter`.
 
-For a list of all reporters supported by `csslint`, see the [csslint wiki](https://github.com/CSSLint/csslint/wiki/Command-line-interface#--format).
+For a list of all formatters supported by `csslint`, see the [csslint wiki](https://github.com/CSSLint/csslint/wiki/Command-line-interface#--format).
 
 ```js
 gulp.task('lint', function() {
   gulp.src('lib/*.css')
     .pipe(csslint())
-    .pipe(csslint.reporter('junit-xml'));
+    .pipe(csslint.formatter('junit-xml'));
 ```
 
-### Custom reporters
+### Custom formatters
 
-Custom reporter functions can be passed as `csslint.reporter(reporterFunc)`. The reporter function will be called for each linted file and passed the file object as described above.
+Custom formatter functions can be passed as `csslint.formatter(formatterFunc)`. The formatter function will be called for each linted file and passed the file object as described above.
 
 ```js
 var csslint = require('gulp-csslint');
 var gutil = require('gulp-util');
 
-var customReporter = function(file) {
+var customFormatter = function(file) {
   gutil.log(gutil.colors.cyan(file.csslint.errorCount)+' errors in '+gutil.colors.magenta(file.path));
 
   file.csslint.results.forEach(function(result) {
@@ -98,18 +98,18 @@ var customReporter = function(file) {
 gulp.task('lint', function() {
   gulp.src('lib/*.css')
     .pipe(csslint())
-    .pipe(csslint.reporter(customReporter));
+    .pipe(csslint.formatter(customFormatter));
 });
 ```
 
-### Reporter options
-You can also pass options to the built-in formatter, by passing a second option to `reporter`.
+### Formatter options
+You can also pass options to the built-in formatter, by passing a second option to `formatter`.
 
 ```js
 gulp.task('lint', function() {
   gulp.src('lib/*.css')
     .pipe(csslint())
-    .pipe(csslint.reporter('junit-xml', options));
+    .pipe(csslint.formatter('junit-xml', options));
 });
 ```
 
@@ -122,7 +122,7 @@ Default is using `process.stdout.write`, but you can use e.g. `console.log`, or 
 gulp.task('lint', function() {
   gulp.src('lib/*.css')
     .pipe(csslint())
-    .pipe(csslint.reporter('junit-xml', {logger: console.log.bind(console)}));
+    .pipe(csslint.formatter('junit-xml', {logger: console.log.bind(console)}));
 });
 ```
 
@@ -130,11 +130,11 @@ gulp.task('lint', function() {
 gulp.task('lint', function() {
   gulp.src('lib/*.css')
     .pipe(csslint())
-    .pipe(csslint.reporter('junit-xml', {logger: gutil.log.bind(null, 'gulp-csslint:')}));
+    .pipe(csslint.formatter('junit-xml', {logger: gutil.log.bind(null, 'gulp-csslint:')}));
 });
 ```
 
-`logger` is called once for the starting format of the reporter, then once for each file containing violations, then
+`logger` is called once for the starting format of the formatter, then once for each file containing violations, then
 lastly once for the ending format. Instead of writing to `stdout`, you can write to file using this option.
 
 ```js
@@ -144,7 +144,7 @@ gulp.task('lint', function(cb) {
 
   gulp.src('lib/*.css')
     .pipe(csslint())
-    .pipe(csslint.reporter('junit-xml', {logger: function(str) { output += str; }}))
+    .pipe(csslint.formatter('junit-xml', {logger: function(str) { output += str; }}))
     .on('end', function(err) {
       if (err) return cb(err);
 
@@ -153,7 +153,7 @@ gulp.task('lint', function(cb) {
 });
 ```
 
-This functionality is only available when not using custom reporters.
+This functionality is only available when not using custom formatters.
 
 ## Custom rules
 
@@ -169,13 +169,13 @@ csslint.addRule({
 gulp.task('lint', function() {
   gulp.src('lib/*.css')
     .pipe(csslint())
-    .pipe(csslint.reporter())
+    .pipe(csslint.formatter())
 });
 ```
 
 ## Fail on errors
 
-Pipe the file stream to `csslint.failReporter()` to fail on errors.
+Pipe the file stream to `csslint.failFormatter()` to fail on errors.
 
 ```js
 var csslint = require('gulp-csslint');
@@ -183,8 +183,8 @@ var csslint = require('gulp-csslint');
 gulp.task('lint', function() {
   gulp.src('lib/*.css')
     .pipe(csslint())
-    .pipe(csslint.reporter()) // Display errors
-    .pipe(csslint.reporter('fail')); // Fail on error (or csslint.failReporter())
+    .pipe(csslint.formatter()) // Display errors
+    .pipe(csslint.formatter('fail')); // Fail on error (or csslint.failFormatter())
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -71,52 +71,52 @@ var cssLintPlugin = function(options) {
   });
 };
 
-cssLintPlugin.reporter = function(customReporter, options) {
-  var reporter = csslint.getFormatter('text');
-  var builtInReporter = true;
+cssLintPlugin.formatter = function(customFormatter, options) {
+  var formatter = csslint.getFormatter('text');
+  var builtInFormatter = true;
   var output;
 
   options = options || {};
 
   var logger = options.logger || process.stdout.write.bind(process.stdout);
 
-  if (typeof customReporter === 'function') {
-    reporter = customReporter;
-    builtInReporter = false;
+  if (typeof customFormatter === 'function') {
+    formatter = customFormatter;
+    builtInFormatter = false;
   }
-  else if (typeof customReporter === 'string') {
-    if (customReporter === 'fail') {
-      return cssLintPlugin.failReporter();
+  else if (typeof customFormatter === 'string') {
+    if (customFormatter === 'fail') {
+      return cssLintPlugin.failFormatter();
     }
 
-    reporter = csslint.getFormatter(customReporter);
+    formatter = csslint.getFormatter(customFormatter);
   }
 
-  if (typeof reporter === 'undefined') {
-    throw new Error('Invalid reporter');
+  if (typeof formatter === 'undefined') {
+    throw new Error('Invalid formatter');
   }
 
-  if (builtInReporter) {
-    output = [reporter.startFormat()];
+  if (builtInFormatter) {
+    output = [formatter.startFormat()];
   }
 
   return through.obj(
     function(file, enc, cb) {
       // Only report if CSSLint was ran and errors were found
       if (file.csslint && !file.csslint.success) {
-        if (builtInReporter) {
-          output.push(reporter.formatResults(file.csslint.originalReport, file.path, options));
+        if (builtInFormatter) {
+          output.push(formatter.formatResults(file.csslint.originalReport, file.path, options));
         }
         else {
-          reporter(file);
+          formatter(file);
         }
       }
 
       return cb(null, file);
     },
     function(cb) {
-      if (builtInReporter) {
-        output.push(reporter.endFormat());
+      if (builtInFormatter) {
+        output.push(formatter.endFormat());
 
         output
           .filter(function(str) {
@@ -137,7 +137,7 @@ cssLintPlugin.addRule = function(rule) {
   csslint.addRule(rule);
 };
 
-cssLintPlugin.failReporter = function() {
+cssLintPlugin.failFormatter = function() {
   return through.obj(function(file, enc, cb) {
     // Nothing to report or no errors
     if (!file.csslint || file.csslint.success) {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
+    "csslint-stylish": "0.0.4",
     "eslint": "^1.1.0",
     "eslint-config-semistandard": "^5.0.0",
     "eslint-config-standard": "^4.1.0",

--- a/test/expected/text.txt
+++ b/test/expected/text.txt
@@ -1,0 +1,11 @@
+csslint: There are 2 problems in test/fixtures/usingImportant.css.
+
+usingImportant.css
+1: warning at line 2, col 1
+Bad naming: .mybox
+.mybox {
+
+usingImportant.css
+2: warning at line 3, col 3
+Use of !important
+  border: 1px solid black !important;

--- a/test/main.js
+++ b/test/main.js
@@ -215,7 +215,7 @@ describe('gulp-csslint', function() {
         browsers: 'All',
 
         // initialization
-        init: function(parser, reporter) {
+        init: function(parser, formatter) {
           'use strict';
           var rule = this;
           parser.addListener('startrule', function(event) {
@@ -230,7 +230,7 @@ describe('gulp-csslint', function() {
                   return;
                 }
                 if (!selector.match(/^\.(_)?(o|c|u|is|has|js|qa)-[a-z0-9]+$/)) {
-                  reporter.warn('Bad naming: ' + selector, line, col, rule);
+                  formatter.warn('Bad naming: ' + selector, line, col, rule);
                 }
               }
             }
@@ -275,7 +275,7 @@ describe('gulp-csslint', function() {
     });
   });
 
-  describe('cssLintPlugin.reporter()', function() {
+  describe('cssLintPlugin.formatter()', function() {
     it('should support built-in CSSLint formatters', function(done) {
       var a = 0;
 
@@ -284,19 +284,19 @@ describe('gulp-csslint', function() {
       var callback = sinon.spy();
 
       var lintStream = cssLintPlugin();
-      var reporterStream = cssLintPlugin.reporter('checkstyle-xml', {logger: callback});
+      var formatterStream = cssLintPlugin.formatter('checkstyle-xml', {logger: callback});
 
-      reporterStream.on('data', function() {
+      formatterStream.on('data', function() {
         ++a;
       });
       lintStream.on('data', function(file) {
-        reporterStream.write(file);
+        formatterStream.write(file);
       });
       lintStream.once('end', function() {
-        reporterStream.end();
+        formatterStream.end();
       });
 
-      reporterStream.once('end', function() {
+      formatterStream.once('end', function() {
         a.should.equal(1);
         sinon.assert.calledThrice(callback);
         callback.firstCall.args[0].should.equal('<?xml version="1.0" encoding="utf-8"?><checkstyle>');
@@ -318,7 +318,7 @@ describe('gulp-csslint', function() {
       var expected = getContents('expected/checkstyle-xml.xml');
 
       var lintStream = cssLintPlugin();
-      var reporterStream = cssLintPlugin.reporter('checkstyle-xml', {
+      var formatterStream = cssLintPlugin.formatter('checkstyle-xml', {
         logger: function(str) {
           output += str;
         }
@@ -326,17 +326,17 @@ describe('gulp-csslint', function() {
 
       sinon.stub(gutil, 'log');
 
-      reporterStream.on('data', function() {
+      formatterStream.on('data', function() {
         ++a;
       });
       lintStream.on('data', function(file) {
-        reporterStream.write(file);
+        formatterStream.write(file);
       });
       lintStream.once('end', function() {
-        reporterStream.end();
+        formatterStream.end();
       });
 
-      reporterStream.once('end', function() {
+      formatterStream.once('end', function() {
         fs.writeFile('test-output.xml', output, function() {
           a.should.equal(1);
           sinon.assert.notCalled(gutil.log);
@@ -365,21 +365,21 @@ describe('gulp-csslint', function() {
       var callback = sinon.spy();
 
       var lintStream = cssLintPlugin();
-      var reporterStream = cssLintPlugin.reporter('text', {logger: callback});
+      var formatterStream = cssLintPlugin.formatter('text', {logger: callback});
 
-      reporterStream.on('data', function() {
+      formatterStream.on('data', function() {
         ++a;
       });
       lintStream.on('data', function(newFile) {
         should.exist(newFile.csslint.success);
         newFile.csslint.success.should.equal(true);
-        reporterStream.write(newFile);
+        formatterStream.write(newFile);
       });
       lintStream.once('end', function() {
-        reporterStream.end();
+        formatterStream.end();
       });
 
-      reporterStream.once('end', function() {
+      formatterStream.once('end', function() {
         sinon.assert.notCalled(callback);
         a.should.equal(1);
 


### PR DESCRIPTION
This PR adds the ability to register custom reporters (or formatters as they're called in CSSLint). I'll add tests and documentation soon (in the next couple of days).
This drops support for custom formatter/reporter that's not a valid CSSLint formatter.
Breakage galore!

This allows us to use for instance https://github.com/SimenB/csslint-stylish with this plugin.

Usage:

```js
var csslint = require('gulp-csslint');

csslint.addFormatter('csslint-stylish');  // Change to reporter?

gulp.task('lint', function() {
  gulp.files('lib/*.css')
    .pipe(csslint())
    .pipe(csslint.reporter('csslint-stylish'))
});
```

Formatters also takes options, which is an object passed as a second param to `reporter`.