### PR TITLE
Don't send empty files to csslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,10 +52,12 @@ var cssLintPlugin = function(options) {
     if (file.isNull()) return cb(null, file); // pass along
     if (file.isStream()) return cb(new error('gulp-csslint: Streaming not supported'));
 
+    var content = file.contents.toString('utf8');
+
+    if (!content) return cb(null, file); // pass along
+
     rcLoader.for(file.path, function(err, opts) {
       if (err) return cb(err);
-
-      var str = file.contents.toString('utf8');
 
       for (var rule in opts) {
         if (!opts[rule]) {
@@ -67,7 +69,7 @@ var cssLintPlugin = function(options) {
         }
       }
 
-      var report = csslint.verify(str, ruleset);
+      var report = csslint.verify(content, ruleset);
 
       // send status down-stream
       file.csslint = formatOutput(report, file, ruleset);

--- a/test/main.js
+++ b/test/main.js
@@ -223,5 +223,25 @@ describe('gulp-csslint', function() {
       stream.write(file);
       stream.end();
     });
+
+    it('should not fail on empty files', function(done) {
+      var a = 0;
+
+      var file = getFile('fixtures/empty.css');
+
+      var stream = cssLintPlugin();
+
+      stream.on('data', function(newFile) {
+        ++a;
+        should.not.exist(newFile.csslint);
+      });
+      stream.once('end', function() {
+        a.should.equal(1);
+        done();
+      });
+
+      stream.write(file);
+      stream.end();
+    });
   });
 });


### PR DESCRIPTION
Fixes #5 #30

Even if CSSlint fixes it so they don't explode, there's no reason we can't short-circuit