### PR TITLE
Add ability to write reports to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.iml
 
 coverage/
+test-output.xml

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ file.csslint.opt = {}; // The options you passed to CSSLint
 
 ## Using reporters
 
-Several reporters come built-in to css-lint. To use one of these reporters, pass the name to `csslint.reporter`.
+Several reporters come built-in to css-lint. To use one of these reporters, pass the name to `csslint.reporter`, along with an optional file path. If the file path is included, the report will be written to this location, instead of printed in the console.
 
 For a list of all reporters supported by `csslint`, see the [csslint wiki](https://github.com/CSSLint/csslint/wiki/Command-line-interface#--format).
 
@@ -77,6 +77,15 @@ gulp.task('lint', function() {
   gulp.files('lib/*.css')
     .pipe(csslint())
     .pipe(csslint.reporter('junit-xml'));
+```
+
+If you want to print the report to disk instead of output to the console, supply the a second optional file path where the file will be written.
+
+```js
+gulp.task('lint', function() {
+  gulp.files('lib/*.css')
+    .pipe(csslint())
+    .pipe(csslint.reporter('junit-xml', 'csslint-junit-report.xml'));
 ```
 
 ### Custom reporters

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var fs = require('fs');
 var gutil = require('gulp-util');
 var through = require('through2');
 var csslint = require('csslint').CSSLint;
@@ -74,7 +75,7 @@ var cssLintPlugin = function(options) {
   });
 };
 
-cssLintPlugin.reporter = function(customReporter) {
+cssLintPlugin.reporter = function(customReporter, filePath) {
   var reporter = csslint.getFormatter('text');
   var builtInReporter = true;
   var output;
@@ -117,7 +118,12 @@ cssLintPlugin.reporter = function(customReporter) {
       if (builtInReporter) {
         output += reporter.endFormat();
 
-        gutil.log(output);
+        if (filePath) {
+          return fs.writeFile(filePath, output, cb);
+        }
+        else {
+          gutil.log(output);
+        }
       }
 
       return cb();


### PR DESCRIPTION
As discussed in #21 

A way to write the report to file would be great, especially for reporters like `junit` and `checkstyle`. I came over https://github.com/juanfran/gulp-scss-lint which writes ti file, but not too cleanly... Other ideas for the API?

On a related note, I'd like to pass options in #29, we could put it in there?
EDIT: If you look at the built in formatters (https://github.com/CSSLint/csslint/tree/master/src/formatters) they take an optionshash. Could just use that? I've already added it in the other PR, so for this it's just be the case of reusing that options-hash

/cc @joshuacc