### PR TITLE
Remove empty line from reporter

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,8 +116,9 @@ cssLintPlugin.reporter = function(customReporter) {
     function(cb) {
       if (builtInReporter) {
         output += reporter.endFormat();
-
-        gutil.log(output);
+        if (output) {
+          gutil.log(output);
+        }
       }
 
       return cb();


### PR DESCRIPTION
In the event that there are no issues with the linting, the `output` from the reporter will be an empty String.

This PR silences that empty String from being logged.

### Before
![before](http://i.imgur.com/LAmqkJ5.png)

### After
![after](http://i.imgur.com/mFDnwNr.png)