### PR TITLE
Only test on LTS releases of node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 sudo: false
 language: node_js
 node_js:
-  - iojs
+  - node
+  - 5
+  - 4
   - 0.12
-  - 0.10
+  - '0.10'
 script: npm run cover
 after_success: cat coverage/lcov.info | node_modules/.bin/coveralls --verbose


### PR DESCRIPTION
Io.js never got any LTS release, while 4 is the first after the merge. `node` is the current release (v5 ATM)