### PR TITLE
Call resume on the stream to emit events

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,9 +144,12 @@ gulp.task('lint', function(cb) {
 
   gulp.src('lib/*.css')
     .pipe(csslint())
-    .pipe(csslint.reporter('junit-xml', {logger: function(str) { output += str; }}));
+    .pipe(csslint.reporter('junit-xml', {logger: function(str) { output += str; }}))
+    .on('end', function(err) {
+      if (err) return cb(err);
 
-  fs.writeFile('some/path/junit.xml', output, cb);
+      fs.writeFile('some/path/junit.xml', output, cb);
+    });
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ cssLintPlugin.reporter = function(customReporter, options) {
 
       return cb();
     }
-  );
+  ).resume(); // Force flow-mode https://nodejs.org/docs/latest/api/stream.html#stream_event_end
 };
 
 cssLintPlugin.addRule = function(rule) {


### PR DESCRIPTION
Fixes #47

I'm unsure why this is needed, may be because of the wrapping that gulp does? Seems like the same issue as pgherveou/gulp-awspublish#13, so I just copied the solution